### PR TITLE
Updating slides for ethereum infrastructure

### DIFF
--- a/content/ethereum-infrastructure/_index.md
+++ b/content/ethereum-infrastructure/_index.md
@@ -1,4 +1,4 @@
-USERNAME--- 
+--- 
 draft: false
 title:  "Ethereum Infrastructure"
 outputs: ["Reveal"]

--- a/content/ethereum-infrastructure/_index.md
+++ b/content/ethereum-infrastructure/_index.md
@@ -195,21 +195,40 @@ Usage:
 
 ---
 
-### Download Geth from Source Code
+### Option 1: Download Geth from Source Code
 
-- get the go-ethereum source code
-- change directory into the code
-- run the make all target, this will create binary files in the `go-ethereum/build/bin/` directory
-
+- Get the go-ethereum source code
 ```bash
 git clone https://github.com/ethereum/go-ethereum.git ~/EthereumInfrastructure/
+```
 
+- Change directory into the code
+```bash
 cd ~/EthereumInfrastructure/go-ethereum
+```
 
+- Run the make all target, this will create binary files in the `go-ethereum/build/bin/` directory
+```bash
 make all
+```
 
-# Optional
+- Add the binaries directory to your path
+```bash
 export PATH="$PATH:~/EthereumInfrastructure/go-ethereum/build/bin/"
+```
+
+---
+
+### Option 2: Download the Geth Pre-Built Binary
+
+- Navigate to the geth downloads website
+https://geth.ethereum.org/downloads/
+
+- Under **Stable releases**, choose the most recent version of **Geth & Tools 1.9.9**. Download the file to your downloads folder.
+
+- After you unzip the tarball, add the binaries directory to your path
+```bash
+export PATH="$PATH:~/Downloads/geth-alltools-darwin-amd64-1.9.9-01744997/"
 ```
 
 ---
@@ -223,7 +242,7 @@ cat /dev/urandom | env LC_CTYPE=C tr -dc a-zA-Z0-9 | head -c 24 > ~/EthereumInfr
 
 Generate an ethereum account
 ```bash
-~/EthereumInfrastructure/go-ethereum/build/cmd/geth --datadir ~/EthereumInfrastructure/private account new --password ~/EthereumInfrastructure/private/keystore/.passphrase
+geth --datadir ~/EthereumInfrastructure/private account new --password ~/EthereumInfrastructure/private/keystore/.passphrase
 ```
 
 ---
@@ -358,15 +377,26 @@ INFO [11-17|23:59:42.875] Saved genesis chain spec                 client=harmon
 }
 ```
 
+{{% note %}}
+- chainId is a way to tell Ethereum chains apart (ETH and ETC both have a network ID of 1 but a chainID of 1 and 61, respectively)
+- 4 required values are config, difficulty, gasLimit, alloc
+- config: The blockchain configuration
+- chainId: protection of the replay attack(an unauthorized user acting as the original sender)
+- homesteadBlock: Homestead is the second major release of Ethereum(the first release is Frontier). The value 0 means that you are using this release
+- epi155Block: epi stands for Ethereum Improvement Proposal, where developers propose ideas on how to improve Ethereum and contribute to this project
+- difficulty: mining difficulty // set this value low so you don’t have to wait too long for mining blocks
+- gasLimit: the limit of gas cost per block // set this value high to avoid being limited when testing
+- alloc: pre-funded address, the first parameter of each is the address . Need to be a 40 digits hex string(160 bit, one hex digit is 4 bit). Note that this does not create an account
+{{% /note %}}
+
 ---
 
 ### Initialize the Ethereum Node
 
 - The init command initializes a new genesis block and definition for the network.
 - You only need to run this command once.
-
 ```bash
-~/EthereumInfrastructure/go-ethereum/build/cmd/geth init ~/EthereumInfrastructure/private/genesis.json --datadir ~/EthereumInfrastructure/private/
+geth init ~/EthereumInfrastructure/private/genesis.json --datadir ~/EthereumInfrastructure/private/
 ```
 
 ---
@@ -375,15 +405,31 @@ INFO [11-17|23:59:42.875] Saved genesis chain spec                 client=harmon
 
 Export your ethereum address
 ```bash
-ETH_ADDRESS="1618dca59ff9aefe8bdd4e8887e7e06a8078bcfb"
+export ETH_ADDRESS="1618dca59ff9aefe8bdd4e8887e7e06a8078bcfb"
 ```
 
 Use the ETH_ADDRESS to start geth
 ```
-~/EthereumInfrastructure/go-ethereum/build/cmd/geth --keystore ~/EthereumInfrastructure/private/keystore --networkid 1234 --unlock ${ETH_ADDRESS} --password ~/EthereumInfrastructure/private/keystore/.passphrase --datadir ~/EthereumInfrastructure/private/ --cache 1024 --port "30303" --rpc --rpcport 8545 --rpcaddr "0.0.0.0" --rpcvhosts "*" --rpccorsdomain "*" --targetgaslimit '800000000' --allow-insecure-unlock
+geth --keystore ~/EthereumInfrastructure/private/keystore --networkid 1234 --unlock ${ETH_ADDRESS} --password ~/EthereumInfrastructure/private/keystore/.passphrase --datadir ~/EthereumInfrastructure/private/ --cache 1024 --port "30303" --rpc --rpcport 8545 --rpcaddr "0.0.0.0" --rpcvhosts "localhost" --rpccorsdomain "*" --targetgaslimit '800000000' --allow-insecure-unlock
 ```
 
 Geth should be running now
+
+{{% note %}}
+--keystore value: Directory for the keystore (default = inside the datadir)
+--networkid value: Network identifier (integer, 1=Frontier, 2=Morden (disused), 3=Ropsten, 4=Rinkeby) (default: 1)
+--unlock value: Comma separated list of accounts to unlock
+--password value: Password file to use for non-interactive password input
+--datadir value: Data directory for the databases and keystore (default: "/home/ligi/.ethereum")
+--cache value: Megabytes of memory allocated to internal caching (default = 4096 mainnet full node, 128 light mode) (default: 1024)
+--port value: Network listening port (default: 30303)
+--rpc: Enable the HTTP-RPC server
+--rpcvhosts value: Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard. (default: "localhost")
+--rpcaddr value: HTTP-RPC server listening interface (default: "localhost")
+--rpccorsdomain value: Comma separated list of domains from which to accept cross origin requests (browser enforced)
+--targetgaslimit value: Target gas floor for mined blocks (deprecated, use --miner.gastarget) (default: 8000000)
+--allow-insecure-unlock: Allow insecure account unlocking when account-related RPCs are exposed by http
+{{% /note %}}
 
 ---
 
@@ -391,7 +437,7 @@ Geth should be running now
 
 In another terminal window, attach the geth.ipc socket
 ```
-$ ~/EthereumInfrastructure/go-ethereum/build/cmd/geth attach ~/EthereumInfrastructure/private/geth.ipc
+$ geth attach ~/EthereumInfrastructure/private/geth.ipc
 Welcome to the Geth JavaScript console!
 
 instance: Geth/v1.9.8-unstable-9e71f55b-20191117/darwin-amd64/go1.13.4
@@ -426,9 +472,9 @@ at block: 0 (Sun, 17 Nov 2019 23:50:19 PST)
 ```bash
 curl -X GET -H "Content-Type: application/json" localhost:8545 --data '{"jsonrpc":"2.0","method":"eth_blockNumber", "params":[], "id":67 }'
 
-curl -X GET -H "Content-Type: application/json" seth-miner.staging.springlabs.network:8545 --data '{"jsonrpc":"2.0","method":"eth_blockNumber", "params":[], "id":67 }' | jq -r '.result' | xargs -n1 printf '%d\n',
+curl -X GET -H "Content-Type: application/json" localhost:8545 --data '{"jsonrpc":"2.0","method":"eth_blockNumber", "params":[], "id":67 }' | jq -r '.result' | xargs -n1 printf '%d\n',
 
-curl -X GET -H "Content-Type: application/json" prod-dcl-seth.springlabs.network:8545 --data '{"jsonrpc":"2.0","method":"eth_getTransactionCount", "params":['0x4129ade4f41099236c96FEa46eA7413fE60c3B41'], "id":67 }'
+curl -X GET -H "Content-Type: application/json" localhost:8545 --data '{"jsonrpc":"2.0","method":"eth_getTransactionCount", "params":['0x4129ade4f41099236c96FEa46eA7413fE60c3B41'], "id":67 }'
 ```
 
 {{% note %}}
@@ -441,7 +487,7 @@ https://github.com/ethereum/wiki/wiki/JSON-RPC
 
 After your ethereum node has initialized
 ```
-$ ~/EthereumInfrastructure/go-ethereum/build/cmd/geth attach geth.ipc
+$ geth attach geth.ipc
 Welcome to the Geth JavaScript console!
 
 instance: Geth/v1.9.8-unstable-9e71f55b-20191117/darwin-amd64/go1.13.4

--- a/content/ethereum-infrastructure/_index.md
+++ b/content/ethereum-infrastructure/_index.md
@@ -1,4 +1,4 @@
---- 
+USERNAME--- 
 draft: false
 title:  "Ethereum Infrastructure"
 outputs: ["Reveal"]
@@ -262,7 +262,7 @@ geth --datadir ~/EthereumInfrastructure/private account new --password ~/Ethereu
 Use the puppeth binary to start the interact prompts and create a genesis file.
 
 ```bash
-$ ~/EthereumInfrastructure/go-ethereum/build/bin/puppeth
+$ puppeth
 +-----------------------------------------------------------+
 | Welcome to puppeth, your Ethereum private network manager |
 |                                                           |
@@ -281,7 +281,7 @@ Please specify a network name to administer (no spaces, hyphens or capital lette
 Sweet, you can set this via --network=myblockchain next time!
 
 INFO [11-17|23:49:34.296] Administering Ethereum network           name=myblockchain
-WARN [11-17|23:49:34.296] No previous configurations found         path=/Users/username/.puppeth/myblockchain
+WARN [11-17|23:49:34.296] No previous configurations found         path=/Users/USERNAME/.puppeth/myblockchain
 
 What would you like to do? (default = stats)
  1. Show network stats
@@ -413,7 +413,7 @@ Use the ETH_ADDRESS to start geth
 geth --keystore ~/EthereumInfrastructure/private/keystore --networkid 1234 --unlock ${ETH_ADDRESS} --password ~/EthereumInfrastructure/private/keystore/.passphrase --datadir ~/EthereumInfrastructure/private/ --cache 1024 --port "30303" --rpc --rpcport 8545 --rpcaddr "0.0.0.0" --rpcvhosts "localhost" --rpccorsdomain "*" --targetgaslimit '800000000' --allow-insecure-unlock
 ```
 
-Geth should be running now
+Geth should be running now.
 
 {{% note %}}
 --keystore value: Directory for the keystore (default = inside the datadir)
@@ -443,7 +443,7 @@ Welcome to the Geth JavaScript console!
 instance: Geth/v1.9.8-unstable-9e71f55b-20191117/darwin-amd64/go1.13.4
 coinbase: 0x1618dca59ff9aefe8bdd4e8887e7e06a8078bcfb
 at block: 0 (Sun, 17 Nov 2019 23:50:19 PST)
- datadir: /Users/username/Documents/git/ethereum_infrastructure/private
+ datadir: /Users/USERNAME/Documents/git/ethereum_infrastructure/private
  modules: admin:1.0 clique:1.0 debug:1.0 eth:1.0 miner:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0
 
 > web3.eth.coinbase
@@ -493,7 +493,7 @@ Welcome to the Geth JavaScript console!
 instance: Geth/v1.9.8-unstable-9e71f55b-20191117/darwin-amd64/go1.13.4
 coinbase: 0x1618dca59ff9aefe8bdd4e8887e7e06a8078bcfb
 at block: 0 (Sun, 17 Nov 2019 23:50:19 PST)
- datadir: /Users/username/Documents/git/ethereum_infrastructure/private
+ datadir: /Users/USERNAME/Documents/git/ethereum_infrastructure/private
  modules: admin:1.0 clique:1.0 debug:1.0 eth:1.0 miner:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0
 
 > admin.nodeInfo.enode
@@ -509,7 +509,7 @@ Enodes are shared amongst peers to tell nodes how to connect to each other.
 Get the geth process ID
 ```bash
 $ ps aux | grep geth
-username           PROCESS_ID   0.0  0.0  4408544    764 s001  S+   10:15PM   0:00.00 geth ...
+USERNAME           PROCESS_ID   0.0  0.0  4408544    764 s001  S+   10:15PM   0:00.00 geth ...
 ```
 
 Use the process ID to stop the geth process

--- a/content/ethereum-infrastructure/_index.md
+++ b/content/ethereum-infrastructure/_index.md
@@ -152,17 +152,17 @@ https://www.binance.vision/blockchain/proof-of-authority-explained
 ### Setup your development environment
 
 Create the project directory
-```
+```bash
 mkdir ~/EthereumInfrastructure
 ```
 
 Create the blockchain data directory
-```
+```bash
 mkdir ~/EthereumInfrastructure/private
 ```
 
 Create the keystore directory
-```
+```bash
 mkdir ~/EthereumInfrastructure/private/keystore
 ```
 
@@ -178,17 +178,37 @@ mkdir ~/EthereumInfrastructure/private/keystore
 
 ---
 
+### Verify Dependencies
+
+After you install go, you will have to close your current terminal window and open a new terminal window to start using the go command.
+
+Verify `go` is working (don't type in the dollar sign)
+```bash
+$ go
+Go is a tool for managing Go source code.
+
+Usage:
+
+	go <command> [arguments]
+...
+```
+
+---
+
 ### Download Geth from Source Code
 
-```
-cd ~/EthereumInfrastructure/go-ethereum/
+- get the go-ethereum source code
+- change directory into the code
+- run the make all target, this will create binary files in the `go-ethereum/build/bin/` directory
 
-git clone https://github.com/ethereum/go-ethereum.git
+```bash
+git clone https://github.com/ethereum/go-ethereum.git ~/EthereumInfrastructure/
 
-cd go-ethereum
+cd ~/EthereumInfrastructure/go-ethereum
 
 make all
 
+# Optional
 export PATH="$PATH:~/EthereumInfrastructure/go-ethereum/build/bin/"
 ```
 
@@ -197,15 +217,13 @@ export PATH="$PATH:~/EthereumInfrastructure/go-ethereum/build/bin/"
 ### Create Ethereum account
 
 Create a password
-```
-cat /dev/urandom | env LC_CTYPE=C tr -dc a-zA-Z0-9 | \  
-head -c 24 > ~/EthereumInfrastructure/private/keystore/.passphrase
+```bash
+cat /dev/urandom | env LC_CTYPE=C tr -dc a-zA-Z0-9 | head -c 24 > ~/EthereumInfrastructure/private/keystore/.passphrase
 ```
 
 Generate an ethereum account
-```
-geth --datadir ~/EthereumInfrastructure/private account new \  
-     --password ~/EthereumInfrastructure/private/keystore/.passphrase
+```bash
+~/EthereumInfrastructure/go-ethereum/build/cmd/geth --datadir ~/EthereumInfrastructure/private account new --password ~/EthereumInfrastructure/private/keystore/.passphrase
 ```
 
 ---
@@ -222,8 +240,10 @@ geth --datadir ~/EthereumInfrastructure/private account new \
 
 ### Create a Genesis File
 
-```
-puppeth
+Use the puppeth binary to start the interact prompts and create a genesis file.
+
+```bash
+$ ~/EthereumInfrastructure/go-ethereum/build/bin/puppeth
 +-----------------------------------------------------------+
 | Welcome to puppeth, your Ethereum private network manager |
 |                                                           |
@@ -237,12 +257,12 @@ puppeth
 +-----------------------------------------------------------+
 
 Please specify a network name to administer (no spaces, hyphens or capital letters please)
-> testing
+> myblockchain
 
-Sweet, you can set this via --network=testing next time!
+Sweet, you can set this via --network=myblockchain next time!
 
-INFO [11-17|23:49:34.296] Administering Ethereum network           name=testing
-WARN [11-17|23:49:34.296] No previous configurations found         path=/Users/sdinay/.puppeth/testing
+INFO [11-17|23:49:34.296] Administering Ethereum network           name=myblockchain
+WARN [11-17|23:49:34.296] No previous configurations found         path=/Users/username/.puppeth/myblockchain
 
 What would you like to do? (default = stats)
  1. Show network stats
@@ -292,12 +312,50 @@ What would you like to do? (default = stats)
 > 2
 
 Which folder to save the genesis specs into? (default = current)
-  Will create testing.json, testing-aleth.json, testing-harmony.json, testing-parity.json
+  Will create myblockchain.json, myblockchain-aleth.json, myblockchain-harmony.json, myblockchain-parity.json
 >
-INFO [11-17|23:59:42.873] Saved native genesis chain spec          path=testing.json
+INFO [11-17|23:59:42.873] Saved native genesis chain spec          path=myblockchain.json
 ERROR[11-17|23:59:42.873] Failed to create Aleth chain spec        err="unsupported consensus engine"
 ERROR[11-17|23:59:42.873] Failed to create Parity chain spec       err="unsupported consensus engine"
-INFO [11-17|23:59:42.875] Saved genesis chain spec                 client=harmony path=testing-harmony.json
+INFO [11-17|23:59:42.875] Saved genesis chain spec                 client=harmony path=myblockchain-harmony.json
+```
+
+---
+
+### Genesis File Example
+
+```
+{
+  "config": {
+    "chainId": 1234,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "clique": {
+      "period": 5,
+      "epoch": 30000
+    }
+  },
+  "nonce": "0x0",
+  "timestamp": "0x5dd24d3b",
+  "extraData": "0x00000000000000000000000000000000000000000000000000000000000000001618dca59ff9aefe8bdd4e8887e7e06a8078bcfb0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "gasLimit": "0x47b760",
+  "difficulty": "0x1",
+  "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "coinbase": "0x0000000000000000000000000000000000000000",
+  "alloc": {
+    ...
+  },
+  "number": "0x0",
+  "gasUsed": "0x0",
+  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+}
 ```
 
 ---
@@ -307,64 +365,39 @@ INFO [11-17|23:59:42.875] Saved genesis chain spec                 client=harmon
 - The init command initializes a new genesis block and definition for the network.
 - You only need to run this command once.
 
-```
-geth init ~/EthereumInfrastructure/private/genesis.json --datadir ~/EthereumInfrastructure/private/
+```bash
+~/EthereumInfrastructure/go-ethereum/build/cmd/geth init ~/EthereumInfrastructure/private/genesis.json --datadir ~/EthereumInfrastructure/private/
 ```
 
 ---
 
 ### Start the Ethereum Node
 
-```
-geth --keystore ~/EthereumInfrastructure/private/keystore \
-  --networkid 1234 \
-  --unlock YOUR_ADDRESS \
-  --password ~/EthereumInfrastructure/private/keystore/.passphrase \
-  --datadir ~/EthereumInfrastructure/private/ \
-  --cache 1024 \
-  --port "30303" \
-  --rpc \
-  --rpcport 8545 \
-  --rpcaddr "0.0.0.0" \
-  --rpcvhosts "*" \
-  --rpccorsdomain "*" \
-  --targetgaslimit '800000000' \
-  --allow-insecure-unlock
+Export your ethereum address
+```bash
+ETH_ADDRESS="1618dca59ff9aefe8bdd4e8887e7e06a8078bcfb"
 ```
 
----
-
-### Start the Ethereum Node in the Background
-
+Use the ETH_ADDRESS to start geth
 ```
-nohup geth --keystore ~/EthereumInfrastructure/private/keystore \
-  --networkid 1234 \
-  --unlock YOUR_ADDRESS \
-  --password ~/EthereumInfrastructure/private/keystore/.passphrase \
-  --datadir ~/EthereumInfrastructure/private/ \
-  --cache 1024 \
-  --port "30303" \
-  --rpc \
-  --rpcport 8545 \
-  --rpcaddr "0.0.0.0" \
-  --rpcvhosts "*" \
-  --rpccorsdomain "*" \
-  --targetgaslimit '800000000' \
-  --allow-insecure-unlock &
+~/EthereumInfrastructure/go-ethereum/build/cmd/geth --keystore ~/EthereumInfrastructure/private/keystore --networkid 1234 --unlock ${ETH_ADDRESS} --password ~/EthereumInfrastructure/private/keystore/.passphrase --datadir ~/EthereumInfrastructure/private/ --cache 1024 --port "30303" --rpc --rpcport 8545 --rpcaddr "0.0.0.0" --rpcvhosts "*" --rpccorsdomain "*" --targetgaslimit '800000000' --allow-insecure-unlock
 ```
+
+Geth should be running now
 
 ---
 
 ### Interact with geth via the console
 
+In another terminal window, attach the geth.ipc socket
 ```
-$ geth attach geth.ipc
+$ ~/EthereumInfrastructure/go-ethereum/build/cmd/geth attach ~/EthereumInfrastructure/private/geth.ipc
 Welcome to the Geth JavaScript console!
 
 instance: Geth/v1.9.8-unstable-9e71f55b-20191117/darwin-amd64/go1.13.4
 coinbase: 0x1618dca59ff9aefe8bdd4e8887e7e06a8078bcfb
 at block: 0 (Sun, 17 Nov 2019 23:50:19 PST)
- datadir: /Users/sdinay/Documents/git/ethereum_infrastructure/private
+ datadir: /Users/username/Documents/git/ethereum_infrastructure/private
  modules: admin:1.0 clique:1.0 debug:1.0 eth:1.0 miner:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0
 
 > web3.eth.coinbase
@@ -390,7 +423,7 @@ at block: 0 (Sun, 17 Nov 2019 23:50:19 PST)
 
 ### Interact with Geth via RPC
 
-```
+```bash
 curl -X GET -H "Content-Type: application/json" localhost:8545 --data '{"jsonrpc":"2.0","method":"eth_blockNumber", "params":[], "id":67 }'
 
 curl -X GET -H "Content-Type: application/json" seth-miner.staging.springlabs.network:8545 --data '{"jsonrpc":"2.0","method":"eth_blockNumber", "params":[], "id":67 }' | jq -r '.result' | xargs -n1 printf '%d\n',
@@ -408,32 +441,34 @@ https://github.com/ethereum/wiki/wiki/JSON-RPC
 
 After your ethereum node has initialized
 ```
-$ geth attach geth.ipc
+$ ~/EthereumInfrastructure/go-ethereum/build/cmd/geth attach geth.ipc
 Welcome to the Geth JavaScript console!
 
 instance: Geth/v1.9.8-unstable-9e71f55b-20191117/darwin-amd64/go1.13.4
 coinbase: 0x1618dca59ff9aefe8bdd4e8887e7e06a8078bcfb
 at block: 0 (Sun, 17 Nov 2019 23:50:19 PST)
- datadir: /Users/sdinay/Documents/git/ethereum_infrastructure/private
+ datadir: /Users/username/Documents/git/ethereum_infrastructure/private
  modules: admin:1.0 clique:1.0 debug:1.0 eth:1.0 miner:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0
 
 > admin.nodeInfo.enode
 "enode://69f40ad0aa4cd732abfbce832fe9c38eab98b1d3b752a3f99b8c109b513b4c12aa97d021f6541450b0ac7a0b61e99c9350132948402bdce926887d04cd6f95f4@38.91.126.179:30303"
 ```
 
-Before your ethereum node has initialized
-```
-$ geth --datadir ~/Documents/git/ethereum_infrastructure/private --keystore ~/Documents/git/ethereum_infrastructure/private/keystore --networkid 1234 --password ~/Documents/git/ethereum_infrastructure/private/keystore/.passphrase console
-
-> admin.nodeInfo.enode
-```
+Enodes are shared amongst peers to tell nodes how to connect to each other.
 
 ---
 
 ### Kill the geth process
 
+Get the geth process ID
+```bash
+$ ps aux | grep geth
+username           PROCESS_ID   0.0  0.0  4408544    764 s001  S+   10:15PM   0:00.00 geth ...
 ```
-pkill geth
+
+Use the process ID to stop the geth process
+```bash
+kill -9 PROCESS_ID
 ```
 
 ---


### PR DESCRIPTION
- Broke up some code blocks.
- Added bullets for readability.
- Fixed the reference to the geth binary.
- Added "Option 2: Download the Geth Pre-Built Binary".
  - another option for downloading the binary, not from source code.
- changed the name of the demo blockchain from `testing` to `myblockchain`.
- added a genesis file example.
- I put the commands on one line, because people in the workshop had different terminal configurations that did not allow them to paste multi-line commands. 